### PR TITLE
remove fyi from dictionary

### DIFF
--- a/resources/dictionary.txt
+++ b/resources/dictionary.txt
@@ -12,7 +12,6 @@ impactful
 ITCR
 itcrtraining
 ITN
-fyi
 Jollife
 Leanpub
 Markua


### PR DESCRIPTION
since the fyi boxes are gone, we can remove "fyi" from the spellcheck dictionary