### PR TITLE
Add student guide rendering

### DIFF
--- a/config_automation.yml
+++ b/config_automation.yml
@@ -26,7 +26,7 @@ render-leanpub: no
 render-coursera: no
 
 ##### Rendering of student guide (if applicable)
-render-student-guide: no
+render-student-guide: yes
 
 ##### Auto-generate a feedback link for the AnVIL Feedback Form: https://docs.google.com/forms/d/e/1FAIpQLScrDVb_utm55pmb_SHx-RgELTEbCCWdLea0T3IzS0Oj00GE4w/viewform
 feedback-link: yes

--- a/student-guide/_bookdown.yml
+++ b/student-guide/_bookdown.yml
@@ -2,7 +2,7 @@ book_filename: "Student_Guide"
 chapter_name: "Chapter "
 repo: https://github.com/jhudsl/AnVIL_Template/
 rmd_files: ["index.Rmd",
-            "05-student_guide.Rmd",
+            "05-student-guide.Rmd",
             "References.Rmd"]
 new_session: yes
 bibliography: [book.bib]

--- a/student-guide/_bookdown.yml
+++ b/student-guide/_bookdown.yml
@@ -2,7 +2,7 @@ book_filename: "Student_Guide"
 chapter_name: "Chapter "
 repo: https://github.com/jhudsl/AnVIL_Template/
 rmd_files: ["index.Rmd",
-            "09-student_guide.Rmd",
+            "05-student_guide.Rmd",
             "References.Rmd"]
 new_session: yes
 bibliography: [book.bib]

--- a/student-guide/_output.yml
+++ b/student-guide/_output.yml
@@ -1,0 +1,3 @@
+bookdown::word_document2:
+  toc: truebookdown::word_document2:
+  toc: true

--- a/student-guide/_output.yml
+++ b/student-guide/_output.yml
@@ -1,3 +1,2 @@
 bookdown::word_document2:
-  toc: truebookdown::word_document2:
   toc: true


### PR DESCRIPTION
per issue #12, enabling the student guide rendering, including a downloadable Docx file. This was most of the way there, but required 
- toggling the option within `config_automation.yml` to yes
- adding an `_output.yml` file which I used the example from the Issue linked course (https://github.com/jhudsl/GDSCN_Book_SARS_Galaxy_on_AnVIL/blob/main/student-guide/_output.yml)
- renaming the student guide file in the `_bookdown.yml` file

The render all action runs successfully when run on this branch: https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_PCA/actions/runs/14716630816